### PR TITLE
Do not display breadcrumbs on empty categories

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -12,7 +12,7 @@ layout: default
 			</div><!-- /.page-image -->
 		</div><!-- /.page-feature -->
 		{% endif %}
-		{% if page.categories %}{% include breadcrumbs.html %}{% endif %}
+		{% if page.categories and page.categories != empty %}{% include breadcrumbs.html %}{% endif %}
 		<div class="page-title">
 			<h1>{{ page.title }}</h1>
 		</div>

--- a/_layouts/media.html
+++ b/_layouts/media.html
@@ -12,7 +12,7 @@ layout: default
 			</div><!-- /.page-image -->
 		</div><!-- /.page-feature -->
 		{% endif %}
-		{% if page.categories %}{% include breadcrumbs.html %}{% endif %}
+		{% if page.categories and page.categories != empty %}{% include breadcrumbs.html %}{% endif %}
 		<div class="page-title">
 			<h1>{{ page.title }}</h1>
 		</div>


### PR DESCRIPTION
Apparently as for jekyll 2.4.0 (I don't know about earlier versions) `page.categories` is always an array, making the condition `if page.categories` insufficient - leading to render ugly breadcrumbs like `HOME / /`.

I've added additional condition to check if aforementioned array is not empty.
